### PR TITLE
Fix typo in "Getting Started" link.

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,4 +26,4 @@ Install or test drive Regolith from scratch with the [LiveCD Installer](https://
 
 ### Next Steps
 
-Have a look at the [Getting Started](/getting-started.html) guide to learn more about using Regolith Linux, see the [latest updates](/news.html), or check out the [configuration](/configuring.html) page to learn about how to tweak it to your liking. Also have a look at the [Keybindings](/keybindings.html) to learn the quickest way around your new desktop environment.
+Have a look at the [Getting Started](/getting_started.html) guide to learn more about using Regolith Linux, see the [latest updates](/news.html), or check out the [configuration](/configuring.html) page to learn about how to tweak it to your liking. Also have a look at the [Keybindings](/keybindings.html) to learn the quickest way around your new desktop environment.


### PR DESCRIPTION
This fixes a dead link on the index page that should lead to the "Getting Started" page.