### PR TITLE
Add pt_br translation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,3 +63,8 @@ defaults:
       path: "fr"
     values:
       lang: "fr"
+  -
+    scope:
+      path: "pt_br"
+    values:
+      lang: "pt_br"

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -15,6 +15,7 @@
     <a class="sidebar-nav-item" href="/sv">🇸🇪 Svenska (sv)</a>
     <a class="sidebar-nav-item" href="/de">🇩🇪 Deutsche (de)</a>
     <a class="sidebar-nav-item" href="/fr">🇫🇷 Français (fr)</a>
+    <a class="sidebar-nav-item" href="/pt_br">🇧🇷 Português (br)</a>
     <a class="sidebar-nav-item" href="https://github.com/search?utf8=✓&q=org%3Aregolith-linux+HowTo+in%3Atitle&type=Wikis">How To</a>
     <a class="sidebar-nav-item" href="https://github.com/regolith-linux/regolith-desktop/wiki">Wiki</a>
     {% comment %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,7 @@
         <li class="lang-list-item"><a class="lang-icon" href="/sv">🇸🇪</a></li>
         <li class="lang-list-item"><a class="lang-icon" href="/de">🇩🇪</a></li>
         <li class="lang-list-item"><a class="lang-icon" href="/fr">🇫🇷</a></li>
+        <li class="lang-list-item"><a class="lang-icon" href="/pt_br">🇧🇷</a></li>
       </ul>
     </div>
 

--- a/pt_br/index.md
+++ b/pt_br/index.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: 
+lang: pt_br
+---
+Regolith é um ambiente de área de trabalho que se desvia completamente das interfaces do Mac ou do Windows para fornecer uma área de trabalho bonita e eficiente. Baseado no Ubuntu e no GNOME, o Regolith possui uma base estável, bem suportada e consistente.
+
+
+<a href="/assets/screenshot-intro.png"><img class="screenshot" alt="Intro Screenshot" src="/assets/screenshot-intro.png"/></a>
+
+[Visual tour of Regolith](/visual-tour.html)
+
+### O que faz o Regolith diferente?
+
+- Fornece aos recursos de gerenciamento de sistema do GNOME o fluxo de trabalho produtivo do [i3](https://i3wm.org/).
+- Permite aos novos usuários uma maneira rápida e divertida de experimentar um [gerenciador de janelas lado a lado](https://opensource.com/article/18/8/i3-tiling-window-manager).
+- É de [fácil personalização](https://github.com/regolith-linux/regolith-desktop/wiki/Customize) e *[ricing](https://www.reddit.com/r/unixporn/)* devido a uma consistente [configuração de Xresource](https://github.com/regolith-linux/regolith-styles/blob/master/Xresources/root).
+- Baseado na [loja de aplicativos do Ubuntu](https://snapcraft.io/store) e seus repositórios para oferecer uma ampla gama de softwares e aplicativos.
+- Oferece uma área de trabalho com um pequeno conjunto de recursos de interface do usuário que podem ser personalizados e expandidos conforme necessário.
+- Exibe, na primeira inicialização, uma seleção de atalhos de teclado para navegar entre janelas, iniciar aplicativos e gerenciar seu sistema.
+- Fornece um [script de build](https://github.com/regolith-linux/regolith-desktop/blob/master/build.sh) e [metadados do pacote](https://github.com/regolith-linux/regolith-desktop/blob/master/package-model.json) para permitir que os usuários alterem e distribuam facilmente o ambiente
+
+### Obtendo o Regolith
+
+Instale ou teste a unidade Regolith do zero com o [LiveCD Installer](https://sourceforge.net/projects/regolith-linux/), ou adicione-a como outra sessão da área de trabalho, caso você já possua o Ubuntu configurado*, instalando o pacote `regolith-desktop` a partir do [Regolith PPA](https://launchpad.net/~kgilmer/+archive/ubuntu/regolith-stable). Veja a [página de instalação](https://github.com/regolith-linux/regolith-desktop/wiki/Install-Regolith) para mais detalhes.
+
+<sub>*Disponível para as versões Ubuntu 18.04 e Ubuntu 19.04</sub>
+
+### Próximos passos
+
+Veja o [Guia de introdução](https://github.com/regolith-linux/regolith-desktop/wiki/Getting-Started) para saber mais sobre o uso do Regolith Linux, consulte as atualizações [mais recentes](/news.html) ou consulte a [página de configuração](https://github.com/regolith-linux/regolith-desktop/wiki/Customize) e a [lista de tutoriais](https://github.com/search?utf8=✓&q=org%3Aregolith-linux+HowTo+in%3Atitle&type=Wikis) para aprender sobre como configurá-lo a seu gosto. Veja também as [teclas de atalho](https://github.com/regolith-linux/regolith-desktop/wiki/Keybindings), pois são a maneira mais rápida de ser uma pessoa produtiva neste novo ambiente. Depois de se familiarizar com o Regolith, consulte os [RfCs ativos](https://github.com/regolith-linux/regolith-desktop/issues?utf8=✓&q=is%3Aissue+is%3Aopen+"Request+for+Comment").
+
+### Contato
+
+|---------|----------|
+| Reportar Bugs | [Issues no Github](https://github.com/regolith-linux/regolith-desktop/issues) |
+| Solicitar novas funcionalidades | [Issues no Github](https://github.com/regolith-linux/regolith-desktop/issues) |
+| Chat | [Canal do Slack](https://regolith-linux.herokuapp.com) |
+| Anúncio de alterações | [Lista de Emails](https://www.freelists.org/list/regolith-linux) |
+
+### Créditos
+
+Regolith é mais uma curadoria do que criação. Aqui estão algumas das pessoas e entidades notáveis que produziram trabalho não afiliado de maneira **independente** no qual a Regolith se baseia.
+
+
+|---------|----------|
+| [Michael Stapelberg](https://i3wm.org) e [Ingo Bürk](https://github.com/Airblader/i3) | Interface Desktop
+| [Dave Davenport](https://github.com/davatorium/rofi) | Interface Desktop
+| [yshui](https://github.com/yshui/compton) | Interface Desktop
+| [Alberts Muktupāvels](https://wiki.gnome.org/Projects/GnomeFlashback) | Interface Desktop
+| [Jesús Castro](https://github.com/jcstr) e [Alex Palaistras](https://github.com/deuill) | Interface Desktop
+| [Vivien Didelot](https://github.com/vivien/i3blocks) | Interface Desktop
+| [Arctic Ice Studio](https://github.com/arcticicestudio) e [Ethan Schoonover](https://ethanschoonover.com/solarized/) | Cores
+| [Eliver Lara](https://github.com/EliverLara/Nordic) | Tema
+| [Sam Hewitt](https://snwh.org/paper) | Ícones
+| [suckless.org](https://st.suckless.org) | Terminal
+| [Lucas Bellator](https://unsplash.com/photos/C0OD8OM-oM0) e [Luca Bravo](https://unsplash.com/photos/xnqVGsbXgV4) | Papel de parede
+| [PJ Singh](https://launchpad.net/cubic) | Infraestrutura
+| [Canonical](https://canonical.com) e [GitHub](https://github.com) | Infraestrutura

--- a/pt_br/visual-tour.md
+++ b/pt_br/visual-tour.md
@@ -1,0 +1,37 @@
+---
+layout: page
+title: Visual Tour
+lang: en
+---
+
+Upon login, Regolith is relatively free of clutter.
+
+<a href="/assets/screenshot-empty.png"><img class="screenshot" alt="Empty Screenshot" src="/assets/screenshot-empty.png"/></a><br/>
+
+For those that do most of their work in the terminal, pressing `<super>`-`<enter>` is all it takes to get to business.
+
+<a href="/assets/screenshot-terminal.png"><img class="screenshot" alt="Terminal Screenshot" src="/assets/screenshot-terminal.png"/></a><br/>
+
+Need more terminals?  Toggle between horizontal and vertical layouts with `<super>`-`<backspace>`.
+
+<a href="/assets/screenshot-terminals.png"><img class="screenshot" alt="Terminals Screenshot" src="/assets/screenshot-terminals.png"/></a><br/>
+
+Launching apps is as simple as `<super>`-`<space>`, type a few letters of the app you're looking for and press `<enter>` to launch it.
+
+<a href="/assets/screenshot-rofi.png"><img class="screenshot" alt="Rofi Screenshot" src="/assets/screenshot-rofi.png"/></a><br/>
+
+GNOME integration provides consistent and simple system management.  Tweak your UI, auto mount your USB drives, connect to a wireless router.
+
+<a href="/assets/screenshot-gnome.png"><img class="screenshot" alt="Gnome Screenshot" src="/assets/screenshot-gnome.png"/></a><br/>
+
+Toggle an overlay that presents the most important keybindings until they become muscle-memory.
+
+<a href="/assets/screenshot-conky.png"><img class="screenshot" alt="Conky Screenshot" src="/assets/screenshot-conky.png"/></a><br/>
+
+Big on multitasking?  Quickly find the window you're looking for via `<super>`-`<ctrl>`-`<space>`.
+
+<a href="/assets/screenshot-window.png"><img class="screenshot" alt="Conky Screenshot" src="/assets/screenshot-window.png"/></a><br/>
+
+Waste no space on frivilous UI and take advantage of every pixel.
+
+<a href="/assets/screenshot-develop.png"><img class="screenshot" alt="Dev Screenshot" src="/assets/screenshot-develop.png"/></a><br/>


### PR DESCRIPTION
I've translated the index page to brazilian portuguese, as https://github.com/regolith-linux/regolith-desktop/issues/144.

For all other languages, the `visual-tour` page was in English, so I didn't know if I could tranlate it, but if you guys need, I can also translate it before you merge this PR.