### PR TITLE
Use shell quotes around regex in apt search in doc

### DIFF
--- a/docs/customize/look/index.html
+++ b/docs/customize/look/index.html
@@ -856,7 +856,7 @@ if (!doNotTrack) {
 	<p>Looks provided by Regolith have the package prefix <code>regolith-look-</code>.  For example, another look sporting the Solarized color palette and a different GTK theme and icon set is called <code>regolith-look-solarized-dark</code>.</p>
 <h2 id="finding-looks">Finding Looks</h2>
 <p>All <code>look</code> packages using this naming scheme can be found via the following command:</p>
-<div class="highlight"><pre style="background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-bash" data-lang="bash">$ apt search ^regolith-look-
+<div class="highlight"><pre style="background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-bash" data-lang="bash">$ apt search '^regolith-look-'
 </code></pre></div><h2 id="installing-a-look">Installing a Look</h2>
 <p>Looks can be installed via the <code>apt</code> tool or with any tool that can install Debian packages on the system, such as <code>synaptic</code>.  For example, this command will install the <code>Ubuntu</code> look:</p>
 <div class="highlight"><pre style="background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-bash" data-lang="bash">$ sudo apt install regolith-look-ubuntu


### PR DESCRIPTION
This PR, which is documentation-only and which does NOT include searching for other instances of this issue, addresses an issue I found when following the docs while using the `fish` shell. Without the quotes included in this PR, my shell reports `apt search ^regolith-looks-` returning no results with no errors. Including the quotes generates the expected result.

I don't know for sure but I believe the issue is that some shells treat `^` as a special character here as part of argument processing. It seems from my brief search that including the quotes doesn't break any other shells and should work in all cases.

PS: I used github's editor to make this change and it appears to have truncated the last line in the file. Sorry about that. I should really just fork this project locally... let me know if you'd prefer I do that first.